### PR TITLE
Disconnect only on provider unmount -- not every rerender.

### DIFF
--- a/src/provider.jsx
+++ b/src/provider.jsx
@@ -23,7 +23,7 @@ export const ActionCableProvider = ({ url, children }) => {
     if (!conn) setConn(createConsumer(url));
 
     return () => conn && conn.disconnect();
-  });
+  }, []);
 
   return <ActionCableContext.Provider value={{ conn }}>{children}</ActionCableContext.Provider>;
 };

--- a/src/useActionCable.js
+++ b/src/useActionCable.js
@@ -16,6 +16,6 @@ export const useActionCable = (params, handlers = {}) => {
       subscription = conn.subscriptions.create(params, handlers);
     }
 
-    return () => subscription && conn.subscriptions.remove(subscription);
+    return () => subscription && subscription.unsubscribe();
   }, [diff]);
 };


### PR DESCRIPTION
Currently, the provider's effect cleanup method gets called on every rerender which is problematic in that it disconnects the consumer. This change ensures that the consumer is only disconnected on unmount. 
I've also included a small stylistic change to unsubscribing using the subscription itself (I can remove this change if you prefer).